### PR TITLE
Ensure JsObject contains a pattern-matchable List of fields

### DIFF
--- a/src/main/scala/play/modules/reactivemongo/PlayBson.scala
+++ b/src/main/scala/play/modules/reactivemongo/PlayBson.scala
@@ -48,8 +48,13 @@ trait ReactiveBSONImplicits extends LowerReactiveBSONImplicits {
 
     def write(obj: JsObject): BSONDocument = {
       BSONDocument(obj.fields.map { tuple =>
-        tuple._1 -> specials.lift(tuple._2).getOrElse(MongoJSONHelpers.toBSON(tuple._2))
+        tuple._1 -> specials.lift(matchable(tuple._2)).getOrElse(MongoJSONHelpers.toBSON(tuple._2))
       }.toStream)
+    }
+
+    private def matchable(obj: JsValue): JsValue = obj match {
+      case JsObject(fields) => JsObject(fields.toList)
+      case other            => other
     }
   }
 


### PR DESCRIPTION
``` scala
case class JsObject(fields: Seq[(String, JsValue)]) extends JsValue {
```

JsObject.fields is not always suitable for pattern matching as a List. Therefore this code can silently fail everytime the fields are not implemented as a List:

https://github.com/ornicar/Play-ReactiveMongo/blob/master/src/main/scala/play/modules/reactivemongo/PlayBson.scala#L42

My patch doesn't look so good, but at least I hope it explains the issue clearly enough.
