### PR TITLE
Fix for save method in JSONCollection

### DIFF
--- a/src/main/scala/play/modules/reactivemongo/jsoncollection.scala
+++ b/src/main/scala/play/modules/reactivemongo/jsoncollection.scala
@@ -139,13 +139,12 @@ case class JSONQueryBuilder(
     if (!sortOption.isDefined && !hintOption.isDefined && !explainFlag && !snapshotFlag && !commentString.isDefined)
       queryOption.getOrElse(Json.obj())
     else {
-      Json.obj(
-        "$query" -> (queryOption.getOrElse(empty): JsObject),
-        "$orderby" -> sortOption,
-        "$hint" -> hintOption,
-        "$comment" -> commentString,
-        "$explain" -> option(explainFlag, JsBoolean(true)),
-        "$snapshot" -> option(snapshotFlag, JsBoolean(true)))
+      Json.obj("$query" -> (queryOption.getOrElse(empty): JsObject)) ++
+        sortOption.map(o => Json.obj("$orderby" -> o)).getOrElse(empty) ++
+        hintOption.map(o => Json.obj("$hint" -> o)).getOrElse(empty) ++
+        commentString.map(o => Json.obj("$comment" -> o)).getOrElse(empty) ++
+        option(explainFlag, JsBoolean(true)).map(o => Json.obj("$explain" -> o)).getOrElse(empty) ++
+        option(snapshotFlag, JsBoolean(true)).map(o => Json.obj("$snapshot" -> o)).getOrElse(empty)
     }
   }
 }


### PR DESCRIPTION
I had some issues with save() method in JSONCollection.

First, I get an infinite loop when I try to use it. This is because Play Writes return a JsValue and not a JsObject.

<pre lang="scala">  def save[T](doc: T, writeConcern: GetLastError = GetLastError())(implicit ec: ExecutionContext, writer: Writes[T]): Future[LastError] =
    save(writer.writes(doc), writeConcern)</pre>

<code>writer.writes(doc)</code> returns an JsValue so we don't call <code>save(doc: JsObject, writeConcern: GetLastError)</code> but we recall <code>save[T](doc: T, writeConcern: GetLastError = GetLastError())</code> with <code>T = JsValue</code>. This is the infinite loop.

The second issue is encountered when I try to save an object which has an _id setted but which does not exist in mongodb. In this case, the object is not saved in the database.

I wrote some unit tests to reproduce these issues easily. I hope that will help you. 

Please let me know if you need any further information.

Edit: I found another issue when I use a sort query. I always get a mongodb error "bad hint (code = 10113)". <code>Json.obj("$hint" -> None)</code> will produce the following json code<code>{$hint:null}</code> and null is not a valid hint for mongo. My pull request include also a fix for that.
