### PR TITLE
Adding BSONSymbol converter

### DIFF
--- a/src/main/scala/play/modules/reactivemongo/bsonhandlers.scala
+++ b/src/main/scala/play/modules/reactivemongo/bsonhandlers.scala
@@ -18,7 +18,7 @@ package play.modules.reactivemongo.json
 import org.jboss.netty.buffer._
 import play.api.libs.json._
 import reactivemongo.bson._
-import reactivemongo.utils.Converters
+import reactivemongo.bson.utils.Converters
 import scala.util.{ Failure, Success, Try }
 
 trait LowerImplicitBSONHandlers {

--- a/src/test/scala/Converters.scala
+++ b/src/test/scala/Converters.scala
@@ -45,5 +45,25 @@ class Converters extends Specification {
       println(doc.map(doc => BSONDocument.pretty(doc)))
       json2 mustEqual json
     }
+    "handle BSONSymbol" in {
+      val symbol = 'sss
+      val bsymbol = BSONSymbol(symbol.toString)
+      val jsymbol = Json.toJson(bsymbol)
+      val bsymbolAgain = Json.fromJson[BSONSymbol](jsymbol)
+      bsymbol mustEqual bsymbolAgain.get
+    }
+    "should convert special Symbol notation" in {
+      val symbol = 'sss
+      val bsymbol = BSONSymbol(symbol.toString)
+      val jsymbol = Json.obj("$symbol" -> symbol.toString)
+      Json.fromJson[BSONSymbol](jsymbol).get mustEqual bsymbol
+    }
+    "should convert special Symbol notation only if there is only one field named $symbol of type String" in {
+      val jsymbol = Json.obj("$symbol" -> "sym", "truc" -> "plop")
+      Json.fromJson[BSONSymbol](jsymbol) match {
+        case JsError(_) => success
+        case success    => failure(s"should not be a JsSuccess $success")
+      }
+    }
   }
 }


### PR DESCRIPTION
Introducing a $symbol notation to handle the conversion between BSON and
JSON.

Also, as a note, on the ReactiveMongo snapshot I built against, it looks like the package location of `Converters` has changed from:

``` scala
import reactivemongo.utils.Converters
```

to

``` scala
import reactivemongo.bson.utils.Converters
```

This is why I updated the `bsonhandlers.scala` file. I can change this back if there is a specific snapshot I should have built against.

Also, I am open to using something besides $symbol, just let me know.

Best,
 -Eric
