### PR TITLE
Added mongodb.uri description to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,11 @@ This plugin reads connection properties from the `application.conf` and gives yo
 mongodb.servers = ["localhost:27017"]
 mongodb.db = "your_db_name"
 ```
-
+alternatively, you can use the URI syntax to point to your MongoDB:
+```
+mongodb.uri ="mongodb://username:password@localhost:27017/your_db_name"
+```
+This is especially helpful on platforms like Heroku, where add-ons publish the connection URI in a single environment variable. The URI syntax supports the following format: `mongodb://[username:password@]host1[:port1][,hostN[:portN]]/dbName`
 
 ### Play2 controller sample
 


### PR DESCRIPTION
Issue https://github.com/zenexity/Play-ReactiveMongo/pull/9 introduced support for URI-style connection strings. I added a few lines to the readme on this feature, to help people find it more quickly. Took me a while before I stumbled across the issue and find the URI support.
