### PR TITLE
Feature mongo collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .classpath
 .project
 .cache
+.idea
+.idea_modules
 *.class
 *.log
 

--- a/project/Play2-ReactiveMongo.scala
+++ b/project/Play2-ReactiveMongo.scala
@@ -129,7 +129,7 @@ object ReactiveMongoBuild extends Build {
       libraryDependencies ++= Seq(
           //"org.reactivemongo" %% "reactivemongo-bson" % "0.1-SNAPSHOT" cross CrossVersion.binary,
         "org.reactivemongo" %% "reactivemongo" % "0.9" cross CrossVersion.binary,
-        "play" %% "play" % "2.1.0" cross CrossVersion.binary,
+        "play" %% "play" % "2.1.1" cross CrossVersion.binary,
         "org.specs2" % "specs2" % "1.13" % "test" cross CrossVersion.binary,
         "junit" % "junit" % "4.8" % "test" cross CrossVersion.Disabled
       )

--- a/project/Play2-ReactiveMongo.scala
+++ b/project/Play2-ReactiveMongo.scala
@@ -2,7 +2,7 @@ import sbt._
 import sbt.Keys._
 
 object BuildSettings {
-  val buildVersion = "0.9"
+  val buildVersion = "0.10-SNAPSHOT"
 
   val buildSettings = Defaults.defaultSettings ++ Seq(
     organization := "org.reactivemongo",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.0
+sbt.version=0.12.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,11 +9,11 @@ resolvers ++= Seq(
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.0.1")
 
-addSbtPlugin("com.jsuereth" % "xsbt-gpg-plugin" % "0.6")
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
 
 addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.2")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.0")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.3")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.0")
 

--- a/samples/Play-ReactiveMongo-Sample/project/build.properties
+++ b/samples/Play-ReactiveMongo-Sample/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.2
+sbt.version=0.12.4

--- a/samples/Play-ReactiveMongo-Sample/project/plugins.sbt
+++ b/samples/Play-ReactiveMongo-Sample/project/plugins.sbt
@@ -1,8 +1,8 @@
 // Comment to get more information during initialization
 logLevel := Level.Warn
 
-// The Typesafe repository 
+// The Typesafe repository
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("play" % "sbt-plugin" % "2.1.0")
+addSbtPlugin("play" % "sbt-plugin" % "2.1.3")

--- a/src/main/scala/play/modules/reactivemongo/MongoCollection.scala
+++ b/src/main/scala/play/modules/reactivemongo/MongoCollection.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2012-2013 Stephane Godbillon (@sgodbillon)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package play.modules.reactivemongo
+
+import scala.concurrent.{ Future, ExecutionContext }
+import reactivemongo.core.commands.{ GetLastError, LastError }
+import play.modules.reactivemongo.json.collection.{ JSONQueryBuilder, JSONGenericHandlers }
+import reactivemongo.api.collections.{ GenericQueryBuilder, GenericCollection }
+import play.api.libs.json.Json.JsValueWrapper
+import scala.reflect.ClassTag
+
+// Reactive Mongo imports
+import reactivemongo.api._
+import reactivemongo.bson._
+
+// Reactive Mongo plugin
+import play.modules.reactivemongo._
+import play.modules.reactivemongo.json.BSONFormats.BSONObjectIDFormat
+
+// Play Json imports
+import play.api.libs.json._
+
+import play.api.Play.current
+
+class MongoCollection[T: ClassTag] extends GenericCollection[JsObject, Reads, Writes] with JSONGenericHandlers with CollectionMetaCommands {
+
+  private def getNameFromClass(implicit ct: ClassTag[T]) = ct.runtimeClass.getName.toLowerCase + "s"
+  def name: String = getNameFromClass
+  def db: DB = ReactiveMongoPlugin.db
+  def failoverStrategy: FailoverStrategy = FailoverStrategy()
+
+  def genericQueryBuilder: GenericQueryBuilder[JsObject, Reads, Writes] = JSONQueryBuilder(this, failoverStrategy)
+
+  private val ID = "_id"
+
+  implicit private def ec: ExecutionContext = ExecutionContext.Implicits.global
+
+  // Not shure this is a good idea, because it doesn't work when named to find, clashes with the existing find method
+  def query(query: (String, JsValueWrapper)*)(implicit ec: ExecutionContext, format: Format[T]): Future[List[T]] = find(Json.obj(query: _*)).cursor[T].toList
+  def findOne(query: (String, JsValueWrapper)*)(implicit ec: ExecutionContext, format: Format[T]): Future[Option[T]] = find(Json.obj(query: _*)).one[T]
+
+  def findById(id: BSONObjectID)(implicit ec: ExecutionContext, format: Format[T]): Future[Option[T]] = findOne(ID -> id)
+  def findById(id: String)(implicit ec: ExecutionContext, format: Format[T]): Future[Option[T]] = findById(BSONObjectID(id))
+
+  def update(id: BSONObjectID, model: T, writeConcern: GetLastError)(implicit ec: ExecutionContext, writer: Writes[T]): Future[LastError] = {
+    update(Json.obj(ID -> id), writer.writes(model).as[JsObject], writeConcern, upsert = true)
+  }
+  def update(id: String, model: T, writeConcern: GetLastError)(implicit ec: ExecutionContext, writer: Writes[T]): Future[LastError] = update(BSONObjectID(id), model, writeConcern)
+
+  def remove(query: (String, JsValueWrapper)*)(implicit ec: ExecutionContext): Future[LastError] = remove(query: _*)
+  def remove(id: BSONObjectID)(implicit ec: ExecutionContext): Future[LastError] = remove(Json.obj(ID -> id))
+  def remove(id: String)(implicit ec: ExecutionContext): Future[LastError] = remove(BSONObjectID(id))
+
+  /*
+    Methods from JSONCollection
+   */
+  def save(doc: JsObject)(implicit ec: ExecutionContext): Future[LastError] = save(doc, GetLastError())
+  def save(doc: JsObject, writeConcern: GetLastError)(implicit ec: ExecutionContext): Future[LastError] = {
+    import reactivemongo.bson._
+    import play.modules.reactivemongo.json.BSONFormats
+    (doc \ "_id" match {
+      case JsUndefined(_) => insert(doc + ("_id" -> BSONFormats.BSONObjectIDFormat.writes(BSONObjectID.generate)), writeConcern)
+      case id             => update(Json.obj("_id" -> id), doc, writeConcern, upsert = true)
+    })
+  }
+  def save(model: T, writeConcern: GetLastError = GetLastError())(implicit ec: ExecutionContext, writer: Writes[T]): Future[LastError] = {
+    save(writer.writes(model).as[JsObject], writeConcern)
+  }
+}

--- a/src/main/scala/play/modules/reactivemongo/MongoCollection.scala
+++ b/src/main/scala/play/modules/reactivemongo/MongoCollection.scala
@@ -37,7 +37,7 @@ import play.api.Play.current
 
 class MongoCollection[T: ClassTag] extends GenericCollection[JsObject, Reads, Writes] with JSONGenericHandlers with CollectionMetaCommands {
 
-  private def getNameFromClass(implicit ct: ClassTag[T]) = ct.runtimeClass.getName.toLowerCase + "s"
+  private def getNameFromClass(implicit ct: ClassTag[T]) = ct.runtimeClass.getSimpleName.toLowerCase + "s"
   def name: String = getNameFromClass
   def db: DB = ReactiveMongoPlugin.db
   def failoverStrategy: FailoverStrategy = FailoverStrategy()
@@ -55,9 +55,11 @@ class MongoCollection[T: ClassTag] extends GenericCollection[JsObject, Reads, Wr
   def findById(id: BSONObjectID)(implicit ec: ExecutionContext, format: Format[T]): Future[Option[T]] = findOne(ID -> id)
   def findById(id: String)(implicit ec: ExecutionContext, format: Format[T]): Future[Option[T]] = findById(BSONObjectID(id))
 
+  def update(id: BSONObjectID, model: T)(implicit ec: ExecutionContext, writer: Writes[T]): Future[LastError] = update(id, model, GetLastError())(ec, writer)
   def update(id: BSONObjectID, model: T, writeConcern: GetLastError)(implicit ec: ExecutionContext, writer: Writes[T]): Future[LastError] = {
     update(Json.obj(ID -> id), writer.writes(model).as[JsObject], writeConcern, upsert = true)
   }
+  def update(id: String, model: T)(implicit ec: ExecutionContext, writer: Writes[T]): Future[LastError] = update(id, model, GetLastError())(ec, writer)
   def update(id: String, model: T, writeConcern: GetLastError)(implicit ec: ExecutionContext, writer: Writes[T]): Future[LastError] = update(BSONObjectID(id), model, writeConcern)
 
   def remove(query: (String, JsValueWrapper)*)(implicit ec: ExecutionContext): Future[LastError] = remove(query: _*)

--- a/src/main/scala/play/modules/reactivemongo/extensions.scala
+++ b/src/main/scala/play/modules/reactivemongo/extensions.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2012-2013 Stephane Godbillon (@sgodbillon)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package play.modules.reactivemongo
+
+import reactivemongo.api.Cursor
+import play.api.libs.json._
+import scala.concurrent.{ ExecutionContext, Future }
+import reactivemongo.bson.BSONObjectID
+
+import scala.annotation.tailrec
+
+package object extensions {
+
+  implicit class StringExtensions(val string: String) extends AnyVal {
+
+    /**
+     * from String to ObjectId
+     * @return
+     */
+    def toBSONObjectID: BSONObjectID = BSONObjectID(string)
+
+    /**
+     * Make slug out of string, stripping all unicode characters and replacing spaces with dashes
+     * @return a slug
+     */
+    def slug: String = {
+      import java.text.Normalizer
+      Normalizer.normalize(string, Normalizer.Form.NFD).trim().replaceAll("[^\\w ]", "").replace(" ", "-").toLowerCase
+    }
+
+    /**
+     * Make a slug unique, by passing in a seq of existing slugs and appending a number until the slug is unique
+     * @param slugs An existing collection of slugs to make unique against
+     * @return a unique slug
+     */
+    def uniqueSlug(slugs: Seq[String]): String = {
+      @tailrec
+      def makeUnique(slug: String, existingSlugs: Seq[String]): String = {
+        if (!(existingSlugs contains slug)) {
+          slug
+        } else {
+          val EndsWithNumber = "(.+-)([0-9]+)$".r
+          slug match {
+            case EndsWithNumber(s, n) => makeUnique(s + (n.toInt + 1), existingSlugs)
+            case s                    => makeUnique(s + "-2", existingSlugs)
+          }
+        }
+      }
+
+      makeUnique(string, slugs)
+    }
+
+  }
+
+  implicit class ListExtensions[T](val futureList: Future[List[T]]) extends AnyVal {
+
+    /**
+     * Converts Future List of type T to an JsArray.
+     * Useful when you want to pipe whatever comes out of reactive mongo directly as json
+     *
+     * @param ec
+     * @param writes
+     * @return
+     */
+    def toJsArray(implicit ec: ExecutionContext, writes: Writes[T]): Future[JsArray] = {
+      futureList.map { futureList =>
+        futureList.foldLeft(JsArray(List()))((obj, item) => obj ++ Json.arr(item))
+      }
+    }
+  }
+
+  implicit class CursorExtensions[T](val cursor: Cursor[T]) extends AnyVal {
+
+    /**
+     * Convert from a List[T] to JsArray[T]
+     * @param ec
+     * @param writes
+     * @return
+     */
+    def toJsArray(implicit ec: ExecutionContext, writes: Writes[T]): Future[JsArray] = {
+      cursor.toList.toJsArray
+    }
+  }
+}

--- a/src/test/scala/Common.scala
+++ b/src/test/scala/Common.scala
@@ -1,0 +1,19 @@
+object Common {
+  import scala.concurrent._
+  import scala.concurrent.duration._
+  import reactivemongo.api._
+
+  implicit val ec = ExecutionContext.Implicits.global
+  /*implicit val writer = DefaultBSONHandlers.DefaultBSONDocumentWriter
+  implicit val reader = DefaultBSONHandlers.DefaultBSONDocumentReader
+  implicit val handler = DefaultBSONHandlers.DefaultBSONReaderHandler*/
+
+  val timeout = 5 seconds
+
+  lazy val connection = new MongoDriver().connection(List("localhost:27017"))
+  lazy val db = {
+    val _db = connection("specs2-test-reactivemongo")
+    Await.ready(_db.drop, timeout)
+    _db
+  }
+}

--- a/src/test/scala/MongoCollectionSpec.scala
+++ b/src/test/scala/MongoCollectionSpec.scala
@@ -9,11 +9,10 @@ import play.modules.reactivemongo.extensions._
 import Common._
 
 case class Post(
-  title: String,
-  content: String,
-  active: Boolean = true,
-  id: Option[BSONObjectID] = None
-) {
+    title: String,
+    content: String,
+    active: Boolean = true,
+    id: Option[BSONObjectID] = None) {
   val slug = title.slug
 }
 

--- a/src/test/scala/MongoCollectionSpec.scala
+++ b/src/test/scala/MongoCollectionSpec.scala
@@ -1,0 +1,57 @@
+import org.specs2.mutable._
+import play.api.libs.iteratee._
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import play.modules.reactivemongo.MongoCollection
+import reactivemongo.bson.BSONObjectID
+import scala.concurrent._
+import play.modules.reactivemongo.extensions._
+import Common._
+
+case class Post(
+  title: String,
+  content: String,
+  active: Boolean = true,
+  id: Option[BSONObjectID] = None
+) {
+  val slug = title.slug
+}
+
+object Post {
+  import play.modules.reactivemongo.json.BSONFormats.BSONObjectIDFormat
+
+  implicit val format = Json.format[Post]
+
+  implicit object collection extends MongoCollection[Post] {
+    // The collection will get it's name from the lower case name of the case class plus an "s" for plural, you can override it if you want.
+    //override def name = "posts"
+
+    // Only needed for test, since it picks up the db from the plugin
+    override def db = Common.db
+  }
+}
+
+class MongoCollectionSpec extends Specification {
+
+  sequential
+
+  "MongoCollectionSpec" should {
+
+    "Create posts" in {
+      import Post._
+      val posts = Seq(
+        Post("This is the first post", "Hello from post 1"),
+        Post("This is a post with something else", "Hello from post 2"),
+        Post("This post is inactive", "I'm inactive", active = false))
+
+      val inserted = Await.result(Post.collection.bulkInsert(Enumerator.enumerate(posts)), timeout)
+      inserted must beEqualTo(3)
+    }
+
+    "Query for active posts" in {
+      val activePosts = Await.result(Post.collection.query("active" -> true), timeout)
+      activePosts.size must beEqualTo(2)
+    }
+  }
+
+}

--- a/src/test/scala/extensions.scala
+++ b/src/test/scala/extensions.scala
@@ -1,0 +1,100 @@
+import org.specs2.mutable._
+import play.api.libs.iteratee._
+import play.modules.reactivemongo.json.collection.JSONCollection
+import reactivemongo.api.FailoverStrategy
+import reactivemongo.bson.BSONObjectID
+import scala.concurrent._
+import play.api.libs.json._
+import play.api.libs.json.util._
+import play.api.libs.json.Reads._
+import play.api.libs.json.Writes._
+
+class extensions extends Specification {
+  import Common._
+
+  import reactivemongo.bson._
+  import play.modules.reactivemongo.json.ImplicitBSONHandlers
+  import play.modules.reactivemongo.json.ImplicitBSONHandlers._
+  import play.modules.reactivemongo.json.BSONFormats._
+  import play.modules.reactivemongo.extensions._
+
+  import play.api.libs.json._
+  import play.api.libs.functional.syntax._
+
+  implicit val userReads = Json.reads[User]
+  implicit val userWrites = Json.writes[User]
+
+  sequential
+  lazy val collectionName = "reactivemongo_test_extensions"
+  lazy val bsonCollection = db(collectionName)
+  lazy val collection = new JSONCollection(db, collectionName, new FailoverStrategy())
+
+  "String Extensions" should {
+    "convert string to BSONObjectID" in {
+      val id = BSONObjectID.generate
+      val stringId = id.stringify
+      stringId.toBSONObjectID mustEqual id
+    }
+
+    "slugify string" in {
+      val title = "Den här titeln är grym!"
+      val slug = title.slug
+      slug must beEqualTo("den-har-titeln-ar-grym")
+    }
+
+    "slugify and make unique" in {
+      val slug1 = "slug"
+      slug1.uniqueSlug(Seq(slug1)) must beEqualTo("slug-2")
+
+      val slug2 = "slug-2"
+      slug1.uniqueSlug(Seq(slug1, slug2)) must beEqualTo("slug-3")
+    }
+  }
+
+  "List Extensions" should {
+    "convert List to JsArray so that we can return it directly in play's controller" in {
+
+      val futureList = Future.successful(List(1, 2, 3))
+      val futureJsArray = futureList.toJsArray
+
+      val jsArray = Await.result(futureJsArray, timeout)
+
+      jsArray must beEqualTo(Json.arr(1, 2, 3))
+    }
+  }
+
+  "Cursor Extensions" should {
+    "convert Cursor to JsArray so that we can return it directly in play's controller" in {
+
+      /*
+        Async {
+          val usersFuture = collection.find(Json.obj()).cursor[JsObject].toJsArray
+          usersFuture.map { users =>
+            ok(users)
+          }
+        }
+
+        or simplified
+        Async {
+          collection.find(Json.obj()).cursor[JsObject].toJsArray.map(ok(_))
+        }
+       */
+
+      // Add Some users
+      val user = User(Some(BSONObjectID.generate), "John Doe")
+      val result = Await.result(collection.save(user), timeout)
+      result.ok must beTrue
+
+      val user2 = User(Some(BSONObjectID.generate), "Jane Doe")
+      val result2 = Await.result(collection.save(user2), timeout)
+      result2.ok must beTrue
+
+      val userJsonArray = Json.arr(
+        userWrites.writes(user),
+        userWrites.writes(user2))
+
+      val fetched1 = Await.result(collection.find(Json.obj()).cursor[JsObject].toJsArray, timeout)
+      fetched1 must beEqualTo(userJsonArray)
+    }
+  }
+}

--- a/src/test/scala/json.scala
+++ b/src/test/scala/json.scala
@@ -6,26 +6,6 @@ import play.api.libs.json.util._
 import play.api.libs.json.Reads._
 import play.api.libs.json.Writes._
 
-object Common {
-  import scala.concurrent._
-  import scala.concurrent.duration._
-  import reactivemongo.api._
-
-  implicit val ec = ExecutionContext.Implicits.global
-  /*implicit val writer = DefaultBSONHandlers.DefaultBSONDocumentWriter
-  implicit val reader = DefaultBSONHandlers.DefaultBSONDocumentReader
-  implicit val handler = DefaultBSONHandlers.DefaultBSONReaderHandler*/
-
-  val timeout = 5 seconds
-
-  lazy val connection = new MongoDriver().connection(List("localhost:27017"))
-  lazy val db = {
-    val _db = connection("specs2-test-reactivemongo")
-    Await.ready(_db.drop, timeout)
-    _db
-  }
-}
-
 case class Expeditor(name: String)
 case class Item(name: String, description: String, occurrences: Int)
 case class Package(


### PR DESCRIPTION
Using Reactive Mongo Coast to Coast works great, but I've been working on simplifying when you want to work with case classes, mainly because passing around case classes to akka Actors and sub systems feels better than sending JsObject.

By implicitly passing a MongoCollection to a controller we can get a simple crud app up and running in a few minutes.

I have not incorporated the ResourceController and MongoResourceController because I'm not shure they belong in Reactive Mongo (though the could, since they are quite light) but since alot of people have their own ideas about what http verbs to use and they use different front end systems, maybe it's better to have it in the docs, or an sample app.

Here are all the files anyway, and the way the routes are setup now, they nicely integrate with angularjs.
https://gist.github.com/leon/5597895

One thing I'm not shure about is being able to do queries without specifying Json.obj see
https://github.com/leon/Play-ReactiveMongo/commit/57b5478a8db3e5e0dad57624f405951e1a34956b#L0R52
It's nice to be able to do collection.query("name" -> "Leon", "active" -> true) but we then loose the option to do sorting, but maybe we could get something nice out of it.

