### PR TITLE
Provide the error message from JsError when parsing failed

### DIFF
--- a/src/main/scala/play/modules/reactivemongo/jsoncollection.scala
+++ b/src/main/scala/play/modules/reactivemongo/jsoncollection.scala
@@ -46,7 +46,10 @@ trait JSONGenericHandlers extends GenericHandlers[JsObject, Reads, Writes] {
     }
   }
   case class BSONStructureReader[T](reader: Reads[T]) extends GenericReader[JsObject, T] {
-    def read(doc: JsObject) = reader.reads(doc).get
+    def read(doc: JsObject) = reader.reads(doc) match {
+      case success: JsSuccess[T] => success.get
+      case error: JsError => throw new NoSuchElementException(error.toString)
+    }
   }
   case class BSONStructureWriter[T](writer: Writes[T]) extends GenericWriter[T, JsObject] {
     def write(t: T) = writer.writes(t).as[JsObject]


### PR DESCRIPTION
If the JSON reader fails, for example the structure of the BSON doc does not match the JSON format we now get a NoSuchElement with no further information of what went wrong. This change adds the details of the JsError in the exception.
