### PR TITLE
Allow custom BSON/JSON (de)serializer for children of documents and arrays

### DIFF
--- a/src/main/scala/play/modules/reactivemongo/json.scala
+++ b/src/main/scala/play/modules/reactivemongo/json.scala
@@ -52,7 +52,7 @@ object BSONFormats {
       case str: BSONString => JsString(str.value)
     }
   }
-  implicit object BSONDocumentFormat extends PartialFormat[BSONDocument] {
+  class BSONDocumentFormat(toBSON: JsValue => JsResult[BSONValue], toJSON: BSONValue => JsValue) extends PartialFormat[BSONDocument] {
     def partialReads: PartialFunction[JsValue, JsResult[BSONDocument]] = {
       case obj: JsObject =>
         try {
@@ -72,7 +72,8 @@ object BSONFormats {
       })
     }
   }
-  implicit object BSONArrayFormat extends PartialFormat[BSONArray] {
+  implicit object BSONDocumentFormat extends BSONDocumentFormat(toBSON, toJSON)
+  class BSONArrayFormat(toBSON: JsValue => JsResult[BSONValue], toJSON: BSONValue => JsValue) extends PartialFormat[BSONArray] {
     def partialReads: PartialFunction[JsValue, JsResult[BSONArray]] = {
       case arr: JsArray =>
         try {
@@ -94,6 +95,7 @@ object BSONFormats {
       }
     }
   }
+  implicit object BSONArrayFormat extends BSONArrayFormat(toBSON, toJSON)
   implicit object BSONObjectIDFormat extends PartialFormat[BSONObjectID] {
     def partialReads: PartialFunction[JsValue, JsResult[BSONObjectID]] = {
       case JsObject(("$oid", JsString(v)) +: Nil) => JsSuccess(BSONObjectID(v))


### PR DESCRIPTION
I use the JSON serializer to create output for a REST API, but need to change how BSONDocumentIDs are serialized. This change makes it easier to change to override how builtin data types are converted, without the need to copy/paste and change several PartialFormats that are already present.
