### PR TITLE
Thread leak - driver doesn't get shut down on stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ libraryDependencies ++= Seq(
 #### add to your conf/play.plugins
 
 ``` 
-400:play.modules.reactivemongo.ReactiveMongoPlugin
+1100:play.modules.reactivemongo.ReactiveMongoPlugin
 ```
 
 


### PR DESCRIPTION
When the ReactiveMongoPlugin is shutdown, it doesn't close the MongoDriver.  The default MongoDriver constructor is used to create it, which means it creates an actor system for itself, and since it doesn't get closed, the actor system doesn't get shut down, leaking many threads every time a Play app is reloaded in dev mode.

Ideally, the ReactiveMongoPlugin should use the actor system provided by the Play Akka plugin, then it doesn't have to worry about shutting it down.
