### PR TITLE
Play24 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-# ReactiveMongo Support to Play! Framework 2.3
+# ReactiveMongo Support to Play! Framework 2.4 (RC5)
 
-This is a plugin for Play 2.3, enabling support for [ReactiveMongo](http://reactivemongo.org) - reactive, asynchronous and non-blocking Scala driver for MongoDB.
+<strong>WARNING!</strong>
+This is not an absolutely stable version.
 
+This is a module for Play 2.4-RC5, enabling support for [ReactiveMongo](http://reactivemongo.org) - reactive, asynchronous and non-blocking Scala driver for MongoDB. It's considered as not stable yet.
+
+If you are looking for a stable version for Play 2.3, please consider using the 0.10.5.0.akka23 version.
 If you are looking for a stable version for Play 2.2, please consider using the 0.10.5.0.akka22 version.
 
 ## Main features

--- a/project/Play2-ReactiveMongo.scala
+++ b/project/Play2-ReactiveMongo.scala
@@ -125,7 +125,7 @@ object Play2ReactiveMongoBuild extends Build {
         "com.typesafe.play" %% "play-test" % "2.4.0-RC5" % "test" cross CrossVersion.binary,
         "org.specs2" % "specs2" % "2.3.12" % "test" cross CrossVersion.binary,
         "junit" % "junit" % "4.8" % "test" cross CrossVersion.Disabled,
-        "org.apache.logging.log4j" % "log4j-to-slf4j" % "2.0-beta9"
+        "org.apache.logging.log4j" % "log4j-to-slf4j" % "2.3"
       )
     )
   )

--- a/project/Play2-ReactiveMongo.scala
+++ b/project/Play2-ReactiveMongo.scala
@@ -2,7 +2,7 @@ import sbt._
 import sbt.Keys._
 
 object BuildSettings {
-  val buildVersion = "0.11.0-SNAPSHOT"
+  val buildVersion = "0.12.0-SNAPSHOT"
 
   val buildSettings = Defaults.defaultSettings ++ Seq(
     organization := "org.reactivemongo",
@@ -120,9 +120,9 @@ object Play2ReactiveMongoBuild extends Build {
         "Typesafe repository snapshots" at "http://repo.typesafe.com/typesafe/snapshots/"
       ),
       libraryDependencies ++= Seq(
-        "org.reactivemongo" %% "reactivemongo" % "0.11.0-SNAPSHOT" cross CrossVersion.binary,
-        "com.typesafe.play" %% "play" % "2.3.0" % "provided" cross CrossVersion.binary,
-        "com.typesafe.play" %% "play-test" % "2.3.0" % "test" cross CrossVersion.binary,
+        "org.reactivemongo" %% "reactivemongo" % "0.10.5.0.akka23" cross CrossVersion.binary,
+        "com.typesafe.play" %% "play" % "2.4.0-RC5" % "provided" cross CrossVersion.binary,
+        "com.typesafe.play" %% "play-test" % "2.4.0-RC5" % "test" cross CrossVersion.binary,
         "org.specs2" % "specs2" % "2.3.12" % "test" cross CrossVersion.binary,
         "junit" % "junit" % "4.8" % "test" cross CrossVersion.Disabled,
         "org.apache.logging.log4j" % "log4j-to-slf4j" % "2.0-beta9"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.2
+sbt.version=0.13.8

--- a/src/main/scala/play/modules/reactivemongo/MongoController.scala
+++ b/src/main/scala/play/modules/reactivemongo/MongoController.scala
@@ -15,6 +15,7 @@
  */
 package play.modules.reactivemongo
 
+import play.core.parsers.Multipart
 import reactivemongo.api._
 import reactivemongo.api.gridfs._
 import reactivemongo.bson._
@@ -38,11 +39,11 @@ trait MongoController {
   val CONTENT_DISPOSITION_INLINE = "inline"
 
   /** Returns a future Result that serves the first matched file, or NotFound. */
-  def serve[T <: ReadFile[_ <: BSONValue], Structure, Reader[_], Writer[_]](gfs: GridFS[Structure, Reader, Writer], foundFile: Cursor[T], dispositionMode: String = CONTENT_DISPOSITION_ATTACHMENT)(implicit ec: ExecutionContext): Future[SimpleResult] = {
+  def serve[T <: ReadFile[_ <: BSONValue], Structure, Reader[_], Writer[_]](gfs: GridFS[Structure, Reader, Writer], foundFile: Cursor[T], dispositionMode: String = CONTENT_DISPOSITION_ATTACHMENT)(implicit ec: ExecutionContext): Future[Result] = {
     foundFile.headOption.filter(_.isDefined).map(_.get).map { file =>
       val en = gfs.enumerate(file)
       val filename = file.filename
-      SimpleResult(
+      Result(
         // prepare the header
         header = ResponseHeader(OK, Map(
           CONTENT_LENGTH -> ("" + file.length),

--- a/src/main/scala/play/modules/reactivemongo/json.scala
+++ b/src/main/scala/play/modules/reactivemongo/json.scala
@@ -37,8 +37,8 @@ object BSONFormats {
 
   implicit object BSONDoubleFormat extends PartialFormat[BSONDouble] {
     val partialReads: PartialFunction[JsValue, JsResult[BSONDouble]] = {
-      case JsNumber(f)                               => JsSuccess(BSONDouble(f.toDouble))
-      case JsObject(("$double", JsNumber(v)) +: Nil) => JsSuccess(BSONDouble(v.toDouble))
+      case JsNumber(f)                             => JsSuccess(BSONDouble(f.toDouble))
+      case JsObject(Seq(("$double", JsNumber(v)))) => JsSuccess(BSONDouble(v.toDouble))
     }
     val partialWrites: PartialFunction[BSONValue, JsValue] = {
       case double: BSONDouble => JsNumber(double.value)
@@ -67,9 +67,9 @@ object BSONFormats {
         }
     }
     val partialWrites: PartialFunction[BSONValue, JsValue] = {
-      case doc: BSONDocument => new JsObject(doc.elements.map { elem =>
+      case doc: BSONDocument => JsObject(doc.elements.map { elem =>
         elem._1 -> toJSON(elem._2)
-      })
+      } toSeq)
     }
   }
   implicit object BSONDocumentFormat extends BSONDocumentFormat(toBSON, toJSON)
@@ -91,14 +91,14 @@ object BSONFormats {
       case array: BSONArray => {
         JsArray(array.values.map { value =>
           toJSON(value)
-        })
+        } toSeq)
       }
     }
   }
   implicit object BSONArrayFormat extends BSONArrayFormat(toBSON, toJSON)
   implicit object BSONObjectIDFormat extends PartialFormat[BSONObjectID] {
     def partialReads: PartialFunction[JsValue, JsResult[BSONObjectID]] = {
-      case JsObject(("$oid", JsString(v)) +: Nil) => JsSuccess(BSONObjectID(v))
+      case JsObject(Seq(("$oid", JsString(v)))) => JsSuccess(BSONObjectID(v))
     }
     val partialWrites: PartialFunction[BSONValue, JsValue] = {
       case oid: BSONObjectID => Json.obj("$oid" -> oid.stringify)
@@ -114,7 +114,7 @@ object BSONFormats {
   }
   implicit object BSONDateTimeFormat extends PartialFormat[BSONDateTime] {
     def partialReads: PartialFunction[JsValue, JsResult[BSONDateTime]] = {
-      case JsObject(("$date", JsNumber(v)) +: Nil) => JsSuccess(BSONDateTime(v.toLong))
+      case JsObject(Seq(("$date", JsNumber(v)))) => JsSuccess(BSONDateTime(v.toLong))
     }
     val partialWrites: PartialFunction[BSONValue, JsValue] = {
       case dt: BSONDateTime => Json.obj("$date" -> dt.value)
@@ -122,7 +122,7 @@ object BSONFormats {
   }
   implicit object BSONTimestampFormat extends PartialFormat[BSONTimestamp] {
     def partialReads: PartialFunction[JsValue, JsResult[BSONTimestamp]] = {
-      case JsObject(("$time", JsNumber(v)) +: Nil) => JsSuccess(BSONTimestamp(v.toLong))
+      case JsObject(Seq(("$time", JsNumber(v)))) => JsSuccess(BSONTimestamp(v.toLong))
     }
     val partialWrites: PartialFunction[BSONValue, JsValue] = {
       case ts: BSONTimestamp => Json.obj("$time" -> ts.value.toInt, "i" -> (ts.value >>> 4))
@@ -159,18 +159,18 @@ object BSONFormats {
       case BSONNull => JsNull
     }
   }
-  implicit object BSONUndefinedFormat extends PartialFormat[BSONUndefined.type] {
-    def partialReads: PartialFunction[JsValue, JsResult[BSONUndefined.type]] = {
-      case _: JsUndefined => JsSuccess(BSONUndefined)
-    }
-    val partialWrites: PartialFunction[BSONValue, JsValue] = {
-      case BSONUndefined => JsUndefined("")
-    }
-  }
+  //  implicit object BSONUndefinedFormat extends PartialFormat[BSONUndefined.type] {
+  //    def partialReads: PartialFunction[JsReadable, JsResult[BSONUndefined.type]] = {
+  //      case _: JsUndefined => JsSuccess(BSONUndefined)
+  //    }
+  //    val partialWrites: PartialFunction[BSONValue, JsReadable] = {
+  //      case BSONUndefined => JsUndefined("")
+  //    }
+  //  }
   implicit object BSONIntegerFormat extends PartialFormat[BSONInteger] {
     def partialReads: PartialFunction[JsValue, JsResult[BSONInteger]] = {
-      case JsObject(("$int", JsNumber(i)) +: Nil) => JsSuccess(BSONInteger(i.toInt))
-      case JsNumber(i)                            => JsSuccess(BSONInteger(i.toInt))
+      case JsObject(Seq(("$int", JsNumber(i)))) => JsSuccess(BSONInteger(i.toInt))
+      case JsNumber(i)                          => JsSuccess(BSONInteger(i.toInt))
     }
     val partialWrites: PartialFunction[BSONValue, JsValue] = {
       case int: BSONInteger => JsNumber(int.value)
@@ -178,8 +178,8 @@ object BSONFormats {
   }
   implicit object BSONLongFormat extends PartialFormat[BSONLong] {
     def partialReads: PartialFunction[JsValue, JsResult[BSONLong]] = {
-      case JsObject(("$long", JsNumber(long)) +: Nil) => JsSuccess(BSONLong(long.toLong))
-      case JsNumber(long)                             => JsSuccess(BSONLong(long.toLong))
+      case JsObject(Seq(("$long", JsNumber(long)))) => JsSuccess(BSONLong(long.toLong))
+      case JsNumber(long)                           => JsSuccess(BSONLong(long.toLong))
     }
     val partialWrites: PartialFunction[BSONValue, JsValue] = {
       case long: BSONLong => JsNumber(long.value)
@@ -212,7 +212,7 @@ object BSONFormats {
   }
   implicit object BSONSymbolFormat extends PartialFormat[BSONSymbol] {
     def partialReads: PartialFunction[JsValue, JsResult[BSONSymbol]] = {
-      case JsObject(("$symbol", JsString(v)) +: Nil) => JsSuccess(BSONSymbol(v))
+      case JsObject(Seq(("$symbol", JsString(v)))) => JsSuccess(BSONSymbol(v))
     }
     val partialWrites: PartialFunction[BSONValue, JsValue] = {
       case BSONSymbol(s) => Json.obj("$symbol" -> s)
@@ -231,7 +231,7 @@ object BSONFormats {
       orElse(BSONLongFormat.partialReads).
       orElse(BSONBooleanFormat.partialReads).
       orElse(BSONNullFormat.partialReads).
-      orElse(BSONUndefinedFormat.partialReads).
+      //      orElse(BSONUndefinedFormat.partialReads).
       orElse(BSONSymbolFormat.partialReads).
       orElse(BSONArrayFormat.partialReads).
       orElse(BSONDocumentFormat.partialReads).
@@ -248,7 +248,7 @@ object BSONFormats {
     orElse(BSONLongFormat.partialWrites).
     orElse(BSONBooleanFormat.partialWrites).
     orElse(BSONNullFormat.partialWrites).
-    orElse(BSONUndefinedFormat.partialWrites).
+    //    orElse(BSONUndefinedFormat.partialWrites).
     orElse(BSONStringFormat.partialWrites).
     orElse(BSONSymbolFormat.partialWrites).
     orElse(BSONArrayFormat.partialWrites).

--- a/src/main/scala/play/modules/reactivemongo/jsoncollection.scala
+++ b/src/main/scala/play/modules/reactivemongo/jsoncollection.scala
@@ -15,6 +15,7 @@
  */
 package play.modules.reactivemongo.json.collection
 
+import play.api.libs.json.Json.JsValueWrapper
 import play.api.libs.json._
 import reactivemongo.api._
 import reactivemongo.api.collections._
@@ -91,10 +92,11 @@ case class JSONCollection(
   def save(doc: JsObject, writeConcern: GetLastError)(implicit ec: ExecutionContext): Future[LastError] = {
     import reactivemongo.bson._
     import play.modules.reactivemongo.json.BSONFormats
-    (doc \ "_id" match {
+    doc \ "_id" match {
       case _: JsUndefined => insert(doc + ("_id" -> BSONFormats.BSONObjectIDFormat.writes(BSONObjectID.generate)), writeConcern)
-      case id             => update(Json.obj("_id" -> id), doc, writeConcern, upsert = true)
-    })
+      case id: JsValue =>
+        update(Json.obj("_id" -> id), doc, writeConcern, upsert = true)
+    }
   }
 
   /**

--- a/src/main/scala/play/modules/reactivemongo/jsoncollection.scala
+++ b/src/main/scala/play/modules/reactivemongo/jsoncollection.scala
@@ -90,11 +90,9 @@ case class JSONCollection(
    * @param writeConcern the [[reactivemongo.core.commands.GetLastError]] command message to send in order to control how the document is inserted. Defaults to GetLastError().
    */
   def save(doc: JsObject, writeConcern: GetLastError)(implicit ec: ExecutionContext): Future[LastError] = {
-    import reactivemongo.bson._
-    import play.modules.reactivemongo.json.BSONFormats
-    doc \ "_id" match {
-      case _: JsUndefined => insert(doc + ("_id" -> BSONFormats.BSONObjectIDFormat.writes(BSONObjectID.generate)), writeConcern)
-      case id: JsValue =>
+    (doc \ "_id").toOption match {
+      case None => insert(doc, writeConcern)
+      case Some(id) =>
         update(Json.obj("_id" -> id), doc, writeConcern, upsert = true)
     }
   }


### PR DESCRIPTION
A fast Play 2.4.0-RC5 compatibility variant.

What was accomplished:
1) I couldn't `publish-local` current `0.11.0-SNAPSHOT`. The problem was in new classes, that were added in ReactiveMongo with `0.11.0-SNAPSHOT`. Some SerializationPacks etc. So, I decided to downgrade ReactiveMongo to `0.10.5.0-akka23`. I couldn't re-factor JSONCollection and other classes, because I just couldn't understand how (not enough comments etc.).
2) Upgraded Play to 2.4.0-RC5;
3) Due to changes in plays JSON API, I've fixed all the incompatibilities. At least, I think all of them.
In my project this fork works pretty well with Play 2.4.0-RC5. I wouldn't say that it's 100% stable, because I didn't test all the aspects. That's just a fast work-around, that allows to work with Play24.