### PR TITLE
Add extension methods to create JsArray from cursor and BSONObjectID from string

### DIFF
--- a/src/test/scala/jsoncollection.scala
+++ b/src/test/scala/jsoncollection.scala
@@ -8,6 +8,7 @@ object JSONCollectionSpec extends org.specs2.mutable.Specification {
 
   import Common._
 
+  import play.api.libs.json.JsObject
   import reactivemongo.bson._
   import reactivemongo.api.commands.WriteResult
   import reactivemongo.api.{ FailoverStrategy, ReadPreference }
@@ -120,6 +121,17 @@ object JSONCollectionSpec extends org.specs2.mutable.Specification {
       collection.find(Json.obj(
         "$query" -> Json.obj(), "$orderby" -> Json.obj("updated" -> -1))).
         aka("find with empty document") must not(throwA[Throwable])
+    }
+  }
+
+  "JSON cursor" should {
+    "return result as a JSON array" in {
+      import play.modules.reactivemongo.json.collection.JsCursor._
+
+      collection.find(Json.obj()).cursor[JsObject].jsArray().
+        map(_.value.map { js => (js \ "username").as[String] }).
+        aka("extracted JSON array") must beEqualTo(List(
+          "Jane Doe", "Robert Roe")).await(timeoutMillis)
     }
   }
 }


### PR DESCRIPTION
I found it helpful to be able to convert a query to a JsArray directly without having to do the awkward conversion from List[JsObject] to JsArray[JsObject]

So I created some shiny new scala 2.10 extension methods


You can use it like this

    def list() = Action { implicit request =>
      Async {
        val users = collection.find(Json.obj()).cursor[JsObject].toJsArray
        users.map { users =>
          Ok(users)
        }
      }
    }

The implementation:

    package extensions

    import reactivemongo.api.Cursor
    import play.api.libs.json._
    import scala.concurrent.{ExecutionContext, Future}
    import reactivemongo.bson.BSONObjectID

    object ReactiveMongoExtensions {

      implicit class ListExtensions[T](val futureList: Future[List[T]]) extends AnyVal {
        def toJsArray(implicit ec: ExecutionContext, writes: Writes[T]): Future[JsArray] = {
          futureList.map { futureList =>
            futureList.foldLeft(JsArray(List()))( (obj, item) => obj ++ Json.arr(item))
          }
        }
      }

      implicit class CursorExtensions[T](val cursor: Cursor[T]) extends AnyVal {
        def toJsArray(implicit ec: ExecutionContext, writes: Writes[T]): Future[JsArray] = {
          cursor.toList.toJsArray
        }
      }

      implicit class BSONObjectIdExtensions(val string: String) extends AnyVal {
        def toBSONObjectID: BSONObjectID = BSONObjectID(string)
      }

    }

The only question is where we should put it, I thought it would be a good idea to import the implicit class into the MongoController.

Cheers!