### PR TITLE
Make ReactiveMongoComponents truely compile-time injectable

### DIFF
--- a/src/main/scala/play/modules/reactivemongo/MongoController.scala
+++ b/src/main/scala/play/modules/reactivemongo/MongoController.scala
@@ -105,7 +105,29 @@ object MongoController {
 
 /** A mixin for controllers that will provide MongoDB actions. */
 trait MongoController {
-  self: Controller with ReactiveMongoComponents =>
+  self: Controller =>
+
+  /**
+   * Provides the MongoDB API
+   *
+   * Either let the DI framework inject the required MongoDB API into your controller:
+   *
+   * {{{
+   * class MyController @Inject() (val reactiveMongoApi: Reactivemongoapi) extends Controller with MongoController {
+   *    ...
+   * }
+   * }}}
+   *
+   * or use the compile-time dependency injection using the [[ReactiveMongoComponents]] trait:
+   *
+   * {{{
+   * class MyController extends Controller with MongoController with ReactiveMongoComponents {
+   *    // you need to provide the abstract members of ReactiveMongoComponents somehow
+   *    ...
+   * }
+   * }}}
+   */
+  def reactiveMongoApi: ReactiveMongoApi
 
   import play.core.parsers.Multipart
   import reactivemongo.api.Cursor

--- a/src/main/scala/play/modules/reactivemongo/ReactiveMongoModule.scala
+++ b/src/main/scala/play/modules/reactivemongo/ReactiveMongoModule.scala
@@ -20,5 +20,9 @@ final class ReactiveMongoModule extends Module {
  * Cake pattern components.
  */
 trait ReactiveMongoComponents {
-  def reactiveMongoApi: ReactiveMongoApi
+  def actorSystem: ActorSystem
+  def configuration: Configuration
+  def applicationLifecycle: ApplicationLifecycle
+
+  def reactiveMongoApi: ReactiveMongoApi = new DefaultReactiveMongoApi(actorSystem, configuration, applicationLifecycle)
 }


### PR DESCRIPTION
As already promised by the documentation on the ReactiveMongo web site,
make the ReactiveMongoComponents trait useful with compile time
dependency injection.