### PR TITLE
Components for Play 2.4.x Scala compile time DI 

### DIFF
--- a/src/main/scala/play/modules/reactivemongo/MongoController.scala
+++ b/src/main/scala/play/modules/reactivemongo/MongoController.scala
@@ -144,7 +144,7 @@ trait MongoController extends Controller { self: ReactiveMongoComponents =>
 
     multipartFormData(Multipart.handleFilePart {
       case Multipart.FileInfo(partName, filename, contentType) =>
-        gfs.iteratee(JSONFileToSave(filename, contentType))
+        gfs.iteratee(JSONFileToSave(Some(filename), contentType))
     })
   }
 

--- a/src/main/scala/play/modules/reactivemongo/MongoController.scala
+++ b/src/main/scala/play/modules/reactivemongo/MongoController.scala
@@ -144,7 +144,7 @@ trait MongoController extends Controller { self: ReactiveMongoComponents =>
 
     multipartFormData(Multipart.handleFilePart {
       case Multipart.FileInfo(partName, filename, contentType) =>
-        gfs.iteratee(JSONFileToSave(Some(filename), contentType))
+        gfs.iteratee(JSONFileToSave(filename, contentType))
     })
   }
 

--- a/src/main/scala/play/modules/reactivemongo/ReactiveMongoModule.scala
+++ b/src/main/scala/play/modules/reactivemongo/ReactiveMongoModule.scala
@@ -22,3 +22,14 @@ final class ReactiveMongoModule extends Module {
 trait ReactiveMongoComponents {
   def reactiveMongoApi: ReactiveMongoApi
 }
+
+/**
+ * Components for compile time injection
+ */
+trait ReactiveMongoApiComponents {
+  def configuration: Configuration
+  def applicationLifecycle: ApplicationLifecycle
+  def actorSystem: ActorSystem
+
+  lazy val reactiveMongoApi: ReactiveMongoApi = new DefaultReactiveMongoApi(actorSystem, configuration, applicationLifecycle)
+}


### PR DESCRIPTION
Hello,

I have added ReactiveMongoApiComponents, similar to https://www.playframework.com/documentation/2.4.x/api/scala/index.html#play.api.libs.ws.ning.NingWSComponents. I needed it while porting a Play 2.2.x application which uses Reactive Mongo to Play 2.4 with compile time DI. It's trivial to do but I thought someone else might needed too. It's my first pull request, if I did something wrong, let me know :).
