### PR TITLE
log4j-to-slf4j dependency is causing an infinite loop

### DIFF
--- a/project/Play2-ReactiveMongo.scala
+++ b/project/Play2-ReactiveMongo.scala
@@ -106,9 +106,7 @@ object ShellPrompt {
   val buildShellPrompt = {
     (state: State) => {
       val currProject = Project.extract(state).currentProject.id
-      "%s:%s:%s> ".format(
-        currProject, currBranch, BuildSettings.buildVersion
-      )
+      s"$currProject:$currBranch:${BuildSettings.buildVersion}> "
     }
   }
 }
@@ -128,14 +126,16 @@ object Play2ReactiveMongoBuild extends Build {
       ),
       libraryDependencies ++= Seq(
         ("org.reactivemongo" %% "reactivemongo" % "0.12.0-SNAPSHOT" cross CrossVersion.binary).
-          exclude("io.netty", "netty")/* provided by Play */,
+          exclude("io.netty", "netty"). // provided by Play
+          exclude("com.typesafe.akka", "*").
+          exclude("com.typesafe.play", "*"),
         "org.reactivemongo" %% "reactivemongo-play-json" % "0.11.9-1" cross CrossVersion.binary,
         "io.netty" % "netty" % "3.10.4.Final" % "provided",
-        "com.typesafe.play" %% "play" % "2.4.2" % "provided" cross CrossVersion.binary,
-        "com.typesafe.play" %% "play-test" % "2.4.2" % "test" cross CrossVersion.binary,
-        "org.specs2" % "specs2" % "2.3.12" % "test" cross CrossVersion.binary,
-        "junit" % "junit" % "4.8" % "test" cross CrossVersion.Disabled,
-        "org.apache.logging.log4j" % "log4j-to-slf4j" % "2.0.2"
+        "com.typesafe.play" %% "play" % "2.4.6" % "provided" cross CrossVersion.binary,
+        "com.typesafe.play" %% "play-test" % "2.4.6" % Test cross CrossVersion.binary,
+        "org.specs2" % "specs2" % "2.3.12" % Test cross CrossVersion.binary,
+        "junit" % "junit" % "4.8" % Test cross CrossVersion.Disabled,
+        "org.apache.logging.log4j" % "log4j-to-slf4j" % "2.0.2" % Test
       )
     )
   )


### PR DESCRIPTION
Hey guys, thanks for the amazing job ! You're a life saver !

By the way, is there a reason why the project needs log4j-to-slf4j ? It's causing an infinite loop in my project. I don't really understand why. But ignoring this library from Play-ReactiveMongo dependency solved my problem.

https://github.com/ReactiveMongo/Play-ReactiveMongo/blob/master/project/Play2-ReactiveMongo.scala#L138

```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/.ivy2/cache/org.apache.logging.log4j/log4j-slf4j-impl/jars/log4j-slf4j-impl-2.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/activator-dist-1.3.5/repository/ch.qos.logback/logback-classic/1.1.3/jars/logback-classic.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
...
[error]   CAUSED BY java.lang.StackOverflowError
[error]   org.apache.logging.log4j.spi.AbstractLoggerAdapter.getLogger(AbstractLoggerAdapter.java:42)
[error]   org.apache.logging.slf4j.Log4jLoggerFactory.getLogger(Log4jLoggerFactory.java:29)
[error]   org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:284)
[error]   org.apache.logging.slf4j.SLF4JLoggerContext.getLogger(SLF4JLoggerContext.java:41)
[error]   org.apache.logging.slf4j.Log4jLoggerFactory.newLogger(Log4jLoggerFactory.java:37)
[error]   org.apache.logging.slf4j.Log4jLoggerFactory.newLogger(Log4jLoggerFactory.java:29)
[error]   org.apache.logging.log4j.spi.AbstractLoggerAdapter.getLogger(AbstractLoggerAdapter.java:47)
[error]   org.apache.logging.slf4j.Log4jLoggerFactory.getLogger(Log4jLoggerFactory.java:29)
[error]   org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:284)
[error]   org.apache.logging.slf4j.SLF4JLoggerContext.getLogger(SLF4JLoggerContext.java:41)
[error]   org.apache.logging.slf4j.Log4jLoggerFactory.newLogger(Log4jLoggerFactory.java:37)
[error]   org.apache.logging.slf4j.Log4jLoggerFactory.newLogger(Log4jLoggerFactory.java:29)
[error]   org.apache.logging.log4j.spi.AbstractLoggerAdapter.getLogger(AbstractLoggerAdapter.java:47)
[error]   org.apache.logging.slf4j.Log4jLoggerFactory.getLogger(Log4jLoggerFactory.java:29)
[error]   org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:284)
[error]   org.apache.logging.slf4j.SLF4JLoggerContext.getLogger(SLF4JLoggerContext.java:41)
[error]   org.apache.logging.slf4j.Log4jLoggerFactory.newLogger(Log4jLoggerFactory.java:37)
[error]   org.apache.logging.slf4j.Log4jLoggerFactory.newLogger(Log4jLoggerFactory.java:29)
[error]   org.apache.logging.log4j.spi.AbstractLoggerAdapter.getLogger(AbstractLoggerAdapter.java:47)
[error]   org.apache.logging.slf4j.Log4jLoggerFactory.getLogger(Log4jLoggerFactory.java:29)
[error]   org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:284)
..
```

To ignore, in build.sbt I did this.
```
"org.reactivemongo" %% "play2-reactivemongo" % "0.11.9" exclude("org.apache.logging.log4j", "log4j-to-slf4j")
```

I have other dependencies that are using log4j library. Could this create any conflicts ?
```
val log4j = Seq("log4j-api", "log4j-core", "log4j-slf4j-impl").map("org.apache.logging.log4j" % _ % "2.3")
val logging = log4j :+ "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0"
```