### PR TITLE
Update README for Play 2.5 and makeover

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,31 @@
-# ReactiveMongo Support to Play! Framework 2.4
+# ReactiveMongo for Play Framework
 
-This is a plugin for Play 2.4, enabling support for [ReactiveMongo](http://reactivemongo.org) - reactive, asynchronous and non-blocking Scala driver for MongoDB.
+[![Travis branch](https://img.shields.io/travis/ReactiveMongo/Play-ReactiveMongo/master.svg)](https://travis-ci.org/ReactiveMongo/Play-ReactiveMongo)
+[![Maven Central](https://img.shields.io/maven-central/v/org.reactivemongo/play2-reactivemongo_2.11.svg)](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.reactivemongo%22%20AND%20a%3A%22play2-reactivemongo_2.11%22)
+
+This is a plugin for [Play Framework](https://www.playframework.com) 2.4 and 2.5, enabling support for [ReactiveMongo](http://reactivemongo.org) – a reactive, asynchronous and non-blocking Scala driver for MongoDB.
+
 
 ## Usage
 
-In your `project/Build.scala`:
+In your `project/Build.scala` or `build.sbt`:
 
 ```scala
+// only for Play 2.5.x
+libraryDependencies ++= Seq(
+  "org.reactivemongo" %% "play2-reactivemongo" % "0.11.11"
+)
+
 // only for Play 2.4.x
 libraryDependencies ++= Seq(
-  "org.reactivemongo" %% "play2-reactivemongo" % release)
+  "org.reactivemongo" %% "play2-reactivemongo" % "0.11.11-play24"
+)
 ```
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.reactivemongo/play2-reactivemongo_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.reactivemongo/play2-reactivemongo_2.11/)
 
 ## Build manually
 
-ReactiveMongo for Play2 can be built from this source repository.
+ReactiveMongo for Play 2 can be built from this source repository.
 
     sbt publish-local
 
@@ -24,13 +33,12 @@ To run the tests, use:
 
     sbt test
 
-[Travis](https://travis-ci.org/ReactiveMongo/Play-ReactiveMongo): ![Travis build status](https://travis-ci.org/ReactiveMongo/Play-ReactiveMongo.png?branch=master)
+> As of Play 2.4, a JDK 1.8+ is required to build this plugin.
 
-> As for [Play Framework](http://playframework.com/) 2.4, a JDK 1.8+ is required to build this plugin.
 
-### Learn More
+## Learn more
 
 - [Complete documentation and tutorials](http://reactivemongo.org/releases/0.11/documentation/tutorial/play2.html)
-- [Search or create issues](https://github.com/ReactiveMongo/Play-ReactiveMongo/issues)
-- [Get help](https://groups.google.com/forum/?fromgroups#!forum/reactivemongo)
+- [Search or create issues](https://github.com/ReactiveMongo/Play-ReactiveMongo/issues) on GitHub
+- Get help in the [ReactiveMongo Google Group](https://groups.google.com/forum/?fromgroups#!forum/reactivemongo) or [Stack Overflow](http://stackoverflow.com/questions/tagged/play-reactivemongo)
 - [Contribute](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)


### PR DESCRIPTION
I have updated the README file and gave it a little makeover.

The main reason is because I overlooked a small but crucial detail in picking the right dependency. I use Play 2.5, but used `0.11.11-play24`, which worked for a while but I ran into strange issues whilst using JSON readers. The official documentation says what to include for 2.5, but not the Readme. I think this could be useful for others too.

Other changes:

- Change title to not mention "2.4", which suggests newer versions are not supported.
- Use SVG badges from shields.io for a more consistent look.
- Move all badges in one line at the top.
- Change link of *Maven Central* badge to a search page for all "play2-reactivemongo_2.11" artifacts to allow a search for all current and previous versions, with and without the "-play24" suffix.
- Some minor grammar changes
- Update link to Play Framework website reflecting the switch to HTTPS (avoid redirects).
- A bit more verbose in the "Learn more" section.
- Add link to Stack Overflow tag "play-reactivemongo".