### PR TITLE
Added default gridFSBodyParser constructor

### DIFF
--- a/src/main/scala/play/modules/reactivemongo/MongoController.scala
+++ b/src/main/scala/play/modules/reactivemongo/MongoController.scala
@@ -186,6 +186,8 @@ trait MongoController extends Controller { self: ReactiveMongoComponents =>
             MultipartFormData.FilePart(partName, filename, contentType, ref)
           }
     }
+    
+  def gridFSBodyParser(gfs: Future[JsGridFS])(implicit readFileReader: Reads[JsReadFile[JsValue]], ec: ExecutionContext, materialize: Materializer): BodyParser[MultipartFormData[Future[JsReadFile[JsValue]]]] = gridFSBodyParser(gfs, { (n, t) => JSONFileToSave(Some(n), t) })
 
   def gridFSBodyParser[Id <: JsValue](gfs: Future[JsGridFS], fileToSave: (String, Option[String]) => JsFileToSave[Id])(implicit readFileReader: Reads[JsReadFile[Id]], materializer: Materializer, ir: Reads[Id]): JsGridFSBodyParser[Id] = {
     implicit def ec: ExecutionContext = materializer.executionContext


### PR DESCRIPTION
# Pull Request Checklist

* [x ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x ] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [x ] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x ] Have you added tests for any changed functionality? (No functionality changed)

## Purpose

This change adds a constructor to gridFSBodyParser that takes just a Future[GridFS] and uses the default JSONFileToSave implementation.

## Background Context

Both Play framework and ReactiveMongo documentation reference the basic gridFSBodyParser(GridFS) constructor, without a FileToSaveImpl arguement. However since version 0.12, there is now a deprecation warning, indicating to "Use `gridFSBodyParser` with `Future[GridFS]`", but the gridFSBodyParser(Future[GridFS]) constructor does not exist.

## References

Are there any relevant issues / PRs / mailing lists discussions? 
Not that I know of.
