### PR TITLE
travis: Enable cross build for Play 2.7 too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,5 @@ before_install: ./.ci_scripts/beforeInstall.sh
 script: ./.ci_scripts/validate.sh
 after_success:
 - export CI_BRANCH=$TRAVIS_BRANCH SCALA_VERSION=$TRAVIS_SCALA_VERSION
-- test "v$PLAY_VERSION" = "v2.6.7" && export CROSS_SCALA_VERSIONS=yes
+- test "v$PLAY_VERSION" = "v2.6.7" -o "v$PLAY_VERSION" = "v2.7.0" && export CROSS_SCALA_VERSIONS=yes
 - ./.ci_scripts/afterSuccess.sh


### PR DESCRIPTION
Play 2.7 still supports Scala 2.11.

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x] Have you added tests for any changed functionality?

## Purpose

Publish artefacts to nexus for Play 2.7 and Scala 2.11 as well as 2.12.
