### PR TITLE
Build against Play 2.7.1 because of binary incompatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
   - env: RELEASE_SUFFIX=play26 PLAY_VERSION=2.6.7 PUBLISHABLE=yes
     jdk: oraclejdk8
     scala: 2.12.8
-  - env: RELEASE_SUFFIX=play27 PLAY_VERSION=2.7.0 PUBLISHABLE=yes
+  - env: RELEASE_SUFFIX=play27 PLAY_VERSION=2.7.1 PUBLISHABLE=yes
     jdk: oraclejdk8
     scala: 2.12.8
 before_install: ./.ci_scripts/beforeInstall.sh

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -46,7 +46,7 @@ object Common {
     Publish.mimaSettings ++ Release.settings)
 
   lazy val playLower = "2.5.0"
-  lazy val playUpper = "2.7.0"
+  lazy val playUpper = "2.7.1"
   lazy val playVer = Def.setting[String] {
     sys.env.get("PLAY_VERSION").getOrElse {
       if (scalaVersion.value startsWith "2.11.") playLower


### PR DESCRIPTION
@cchantep Can you please publish a new release? Thanks!

See https://blog.playframework.com/play-2-7-1-released/

> Play-JSON also has a breaking change. It was depending [scala-collection-compat](https://github.com/scala/scala-collection-compat), but this library does not guarantees binary compatibility at this point, so we removed the dependency and copy some relevant code inside Play-JSON instead. If your application is using scala-collection-compat as a transitive dependency, or either if it uses a library that uses Play-JSON, these libraries will need to adapt to this change.

I already ran into this problem here: https://github.com/playframework/play-json/issues/259